### PR TITLE
2.0.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: php-actions/composer@v6
+      - uses: shivammathur/setup-php@v2
         with:
-          php_version: "8.4"
+          php-version: "8.4"
+          tools: composer:v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 25
+          node-version: 22
           cache: 'npm'
       - run: npm install
       - run: ./package.sh

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Súdwest-Fryslân, sanderdekroon
 Tags: sudwestfryslan, officielebekendmakingen, government publications, owc
 Requires at least: 5.1
 Tested up to: 6.4
-Requires PHP: 7.4
+Requires PHP: 8.4
 Stable tag: 2.0.10
  
 Import and publish Government Publications through the REST API.


### PR DESCRIPTION
Update PHP requirement to 8.4 in readme and adjust GitHub Actions workflow to use updated PHP setup and Node.js version 22.